### PR TITLE
Adjust for GitHub-flavored Markdown headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Presentation code and slides
 ============================
 
-##License
+## License
 
 ![Creative Commons License](http://i.creativecommons.org/l/by/3.0/88x31.png "Creative Commons License")
 
@@ -9,11 +9,11 @@ Presentation Material by [G. Andrew Duthie](http://devhammer.net) is licensed un
 
 Note that individual presentations may have their own separate license that completely supersede this license.
 
-##Feedback
+## Feedback
 
 If you have any questions, suggestions, or feedback on any of my material, please contact me through [my blog](http://devhammer.net/contact).
 
-##IMPORTANT
+## IMPORTANT
 
 The code included in this repository was created for demo purposes, and as such, may not reflect best practices on 
 exception handling, security, architecture, or other critical aspects of application development. The code is provided 


### PR DESCRIPTION
Somewhere along the line, GitHub stopped respecting headers without a space between the `#`s and the header text, so just adding that space to allow it to render properly.